### PR TITLE
waitroom.htmlで表示されている科目以外の他の科目の追加

### DIFF
--- a/src/main/java/ipeko/tonbanjan/controller/TonbanjanController.java
+++ b/src/main/java/ipeko/tonbanjan/controller/TonbanjanController.java
@@ -52,6 +52,7 @@ public class TonbanjanController {
   public String go_waitroom(ModelMap model, Principal prin) {
     ArrayList<Class> classlist = cMapper.selectAllclass();
     model.addAttribute("classlist", classlist);
+
     return "waitroom.html";
   }
 
@@ -144,5 +145,18 @@ public class TonbanjanController {
 
     }
     return emitter;
+  }
+
+  @PostMapping("/addClass")
+  public String addClass(@RequestParam String className, ModelMap model, Principal prin) {
+
+    Class addClass = new Class();
+    addClass.setclassName(className);
+    cMapper.InsertClass(addClass);
+
+    ArrayList<Class> classlist = cMapper.selectAllclass();
+    model.addAttribute("classlist", classlist);
+
+    return "waitroom.html";
   }
 }

--- a/src/main/java/ipeko/tonbanjan/model/ClassMapper.java
+++ b/src/main/java/ipeko/tonbanjan/model/ClassMapper.java
@@ -14,4 +14,9 @@ public interface ClassMapper {
 
   @Select("SELECT * FROM class WHERE classId = #{classId}")
   Class selectByClassId(int id);
+
+  @Insert("INSERT INTO class (className) VALUES (#{className});")
+  @Options(useGeneratedKeys = true, keyColumn = "classId", keyProperty = "classId")
+  void InsertClass(Class addclass);
+
 }

--- a/src/main/resources/templates/waitroom.html
+++ b/src/main/resources/templates/waitroom.html
@@ -13,13 +13,21 @@
     <div sec:authentication="name" />
   </h2>
 
+  <div sec:authorize="hasRole('ROLE_ADMIN')" th:object="${class}">
+    <h3>アンケートを集計する科目を追加</h3>
+      <form th:action="@{/addClass}" method="post">
+        <input type="text" name="className"/>
+        <input type="submit" value="追加"><input type="reset" value="リセット">
+      </form>
+  </div>
+
   <h3>収集中のアンケート</h3>
   <p>
     <ul>
       <li th:each="class : ${classlist}"><a th:href="@{/class(id=${class.classId})}"> [[${class.className}]]</a></li>
     </ul>
     </p>
-  
+
 
   <h3>収集済みのアンケート</h3>
   <div th:if="${offroom}">


### PR DESCRIPTION
ADMINロールでログインすると、科目の追加欄が表示され、追加したい科目名(例:情報システム応用演習)を入力し、追加ボタンを押すと、waitroom.htmlに新たに追加した科目(例:情報システム応用演習)のリンクが表示されている。
classテーブルに、classId=6, className=”情報システム応用演習”の行が追加されている。
